### PR TITLE
Add PlonkyPOD verify case at POD::verify, add execute_plonky_gadget

### DIFF
--- a/pod2/src/lib.rs
+++ b/pod2/src/lib.rs
@@ -331,6 +331,19 @@ where
 
     /// This is a helper method that just verifies the PlonkyProof contained inside the POD
     pub fn verify_plonky_pod(verifier_data: VerifierCircuitData<F, C, D>, pod: POD) -> Result<()> {
+        // get the PlonkyProof from the pod.proof
+        let proof = match pod.proof.clone() {
+            PODProof::Plonky(p) => Ok(p),
+            _ => Err(anyhow!("Expected PODProof's Plonky variant")),
+        }?;
+        Self::verify_plonky_proof(verifier_data, proof)
+    }
+
+    /// This is a helper method that just verifies the given PlonkyProof
+    pub fn verify_plonky_proof(
+        verifier_data: VerifierCircuitData<F, C, D>,
+        proof: PlonkyProof,
+    ) -> Result<()> {
         let public_inputs = [
             // add verifier_data as public inputs:
             verifier_data.verifier_only.circuit_digest.elements.to_vec(),
@@ -343,12 +356,6 @@ where
                 .collect(),
         ]
         .concat();
-
-        // get the PlonkyProof from the pod.proof
-        let proof = match pod.proof.clone() {
-            PODProof::Plonky(p) => Ok(p),
-            _ => Err(anyhow!("Expected PODProof's Plonky variant")),
-        }?;
 
         // verify the PlonkyProof
         verifier_data.verify(plonky2::plonk::proof::ProofWithPublicInputs {


### PR DESCRIPTION
Needed to set M,N,NS type generics to the methods in order to be able to call the sub-methods (also to be able to generate the circuit_data/verifier_data on the fly).

At some point in a future iteration we should try to update the interfaces so that the circuit_data/verifier_data is not computed each time but passed as parameter.