### PR TITLE
Add recursive circuit public inputs:

### DIFF
--- a/pod2/src/pod/circuit/origin.rs
+++ b/pod2/src/pod/circuit/origin.rs
@@ -25,6 +25,10 @@ impl OriginTarget {
             gadget_id: builder.add_virtual_target(),
         }
     }
+    pub fn register_as_public_input(&self, builder: &mut CircuitBuilder<F, D>) {
+        builder.register_public_input(self.origin_id);
+        builder.register_public_input(self.gadget_id);
+    }
     pub fn to_targets(&self) -> Vec<Target> {
         vec![self.origin_id, self.gadget_id]
     }

--- a/pod2/src/pod/circuit/pod.rs
+++ b/pod2/src/pod/circuit/pod.rs
@@ -173,8 +173,10 @@ impl<const NS: usize> InnerCircuitTrait for SchnorrPODGadget<NS> {
         pw: &mut PartialWitness<F>,
         pod_target: &Self::Targets, // targets = schnorr_pod_target
         pod: &Self::Input,          // input = pod
-    ) -> Result<()> {
-        pod_target.set_witness(pw, pod)
+    ) -> Result<Vec<F>> {
+        pod_target.set_witness(pw, pod)?;
+        // no public inputs at SchnorrPODGadget, return empty vec
+        Ok(vec![])
     }
 }
 

--- a/pod2/src/pod/circuit/statement.rs
+++ b/pod2/src/pod/circuit/statement.rs
@@ -70,6 +70,16 @@ impl StatementTarget {
             value: builder.add_virtual_target(),
         }
     }
+    pub fn register_as_public_input(&self, builder: &mut CircuitBuilder<F, D>) {
+        builder.register_public_input(self.predicate);
+        self.origin1.register_as_public_input(builder);
+        builder.register_public_input(self.key1);
+        self.origin2.register_as_public_input(builder);
+        builder.register_public_input(self.key2);
+        self.origin3.register_as_public_input(builder);
+        builder.register_public_input(self.key3);
+        builder.register_public_input(self.value);
+    }
     pub fn to_targets(&self) -> Vec<Target> {
         [
             vec![self.predicate],

--- a/pod2/src/pod/mod.rs
+++ b/pod2/src/pod/mod.rs
@@ -110,9 +110,9 @@ impl POD {
                 // this method.
                 let circuit_data = PlonkyButNotPlonkyGadget::<M, N, NS>::circuit_data()?;
                 let verifier_data = circuit_data.verifier_data();
-                PlonkyButNotPlonkyGadget::<M, N, NS>::verify_plonky_proof(
+                PlonkyButNotPlonkyGadget::<M, N, NS>::verify_plonky_pod(
                     verifier_data,
-                    p.clone(),
+                    self.clone(),
                 )?;
                 Ok(true)
             }

--- a/pod2/src/recursion/traits.rs
+++ b/pod2/src/recursion/traits.rs
@@ -24,12 +24,13 @@ pub trait InnerCircuitTrait {
         selector_booltarg: &BoolTarget,
     ) -> Result<Self::Targets>;
 
-    /// set the actual witness values for the current instance of the circuit
+    /// set the actual witness values for the current instance of the circuit. Returns a Vec<F>
+    /// containing the values that will be set as public inputs
     fn set_targets(
         pw: &mut PartialWitness<F>,
         targets: &Self::Targets,
         input: &Self::Input,
-    ) -> Result<()>;
+    ) -> Result<Vec<F>>;
 }
 
 pub trait OpsExecutorTrait {
@@ -40,11 +41,12 @@ pub trait OpsExecutorTrait {
     /// sets up the circuit logic
     fn add_targets(builder: &mut CircuitBuilder<F, D>) -> Result<Self::Targets>;
 
-    /// assigns the given Input to the given Targets
+    /// assigns the given Input to the given Targets. Returns a Vec<F> containing the values that
+    /// will be set as public inputs
     fn set_targets(
         pw: &mut PartialWitness<F>,
         targets: &Self::Targets,
         input: &Self::Input,
         output: &Self::Output,
-    ) -> Result<()>;
+    ) -> Result<Vec<F>>;
 }

--- a/pod2/src/recursion/traits_examples.rs
+++ b/pod2/src/recursion/traits_examples.rs
@@ -63,13 +63,13 @@ impl InnerCircuitTrait for ExampleGadget {
         pw: &mut PartialWitness<F>,
         targets: &Self::Targets,
         pod: &Self::Input,
-    ) -> Result<()> {
+    ) -> Result<Vec<F>> {
         // set signature related values:
         targets.pk_targ.set_witness(pw, &pod.pk).unwrap();
         targets.sig_targ.set_witness(pw, &pod.sig).unwrap();
         targets.msg_targ.set_witness(pw, &pod.msg).unwrap();
 
-        Ok(())
+        Ok(vec![])
     }
 }
 
@@ -91,7 +91,7 @@ impl<const NS: usize> OpsExecutorTrait for ExampleOpsExecutor<NS> {
         _targets: &Self::Targets,
         _input: &Self::Input,
         _output: &Self::Output,
-    ) -> Result<()> {
-        Ok(())
+    ) -> Result<Vec<F>> {
+        Ok(vec![])
     }
 }


### PR DESCRIPTION
It is done so that the recursion logic is agnostic to which data structures are public inputs, and is the `InnerCircuit` & `OpsExecutor` who internally define which targets are the public inputs and which are the values that are used as public inputs for those targets.

For example at the current version, the `SchnorrPODGadget` which implements the `InnerCircuitTrait`, returns an empty `Vec<F>=vec![]`; and the `OpExecutorGadget` which implements the `OpsExecutorTrat` returns a `Vec<F>` that comes from the values `Vec<Statement>`; so that in the `RecursiveCircuit` the only public inputs appart from the `VerifierData` are the ones of the `OpExecutorGadget`. So, the public inputs in the PlonkyPOD are the values of the output list of statements (Vec<Statement>).